### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Set Environment
       run: echo "TAG=$(printf %06d $GITHUB_RUN_NUMBER)-$(git rev-parse HEAD)" >> $GITHUB_ENV
     - name: Build Docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: dcr.dbeal.dev/beald/speedrun-browser
         registry: dcr.dbeal.dev


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore